### PR TITLE
feat: Handled on getProfile event

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,20 @@ infrastructure__lists__count: ### Count lists
 infrastructure__lists__query: ### Query lists
 	@/bin/bash -c '. fun.sh && infrastructure__lists__query'
 
+infrastructure__lists__next_event_id: ### Next list event id
+	@/bin/bash -c '. fun.sh && infrastructure__lists__next_event_id'
+
 infrastructure__lists__next_id: ### Next list id
 	@/bin/bash -c '. fun.sh && infrastructure__lists__next_id'
+
+infrastructure__publishers__count: ### Count publishers
+	@/bin/bash -c '. fun.sh && infrastructure__publishers__count'
+
+infrastructure__publishers__query: ### Query publishers
+	@/bin/bash -c '. fun.sh && infrastructure__publishers__query'
+
+infrastructure__publishers__next_id: ### Next publisher id
+	@/bin/bash -c '. fun.sh && infrastructure__publishers__next_id'
 
 com__atproto__repo__createRecord: ### com.atproto.repo.createRecord
 	@/bin/bash -c '. fun.sh && com__atproto__repo__createRecord'

--- a/fun.sh
+++ b/fun.sh
@@ -99,6 +99,13 @@ function infrastructure__lists__query() {
         ./src/infrastructure/repository/repository_lists.pl
 }
 
+function infrastructure__lists__next_event_id() {
+    configure
+
+    scryer -g 'next_event_id(Result), writeq(Result).' -g 'halt.' \
+        ./src/infrastructure/repository/repository_lists.pl
+}
+
 function infrastructure__lists__next_id() {
     configure
 
@@ -125,6 +132,27 @@ function infrastructure__list_items__next_id() {
 
     scryer -g 'next_id(Result), writeq(Result).' -g 'halt.' \
         ./src/infrastructure/repository/repository_list_items.pl
+}
+
+function infrastructure__publishers__count() {
+    configure
+
+    scryer -g 'count(Count), writeq(Count), halt.' \
+        ./src/infrastructure/repository/repository_publishers.pl
+}
+
+function infrastructure__publishers__query() {
+    configure
+
+    scryer -g 'query(Result), writeq(Result).' -g 'halt.' \
+        ./src/infrastructure/repository/repository_publishers.pl
+}
+
+function infrastructure__publishers__next_id() {
+    configure
+
+    scryer -g 'next_id(Result), writeq(Result).' -g 'halt.' \
+        ./src/infrastructure/repository/repository_publishers.pl
 }
 
 # https://docs.bsky.app/docs/api/app-bsky-graph-get-lists

--- a/src/api.pl
+++ b/src/api.pl
@@ -1,13 +1,20 @@
 :- module('api', [endpoint_spec_pairs/2]).
 
+:- use_module(library(charsio)).
 :- use_module(library(dif)).
 :- use_module(library(files)).
 :- use_module(library(lists)).
 :- use_module(library(reif)).
 :- use_module(library(si)).
+:- use_module(library(crypto)).
 :- use_module(library(serialization/json)).
 
-:- use_module(stream, [read_stream/3]).
+:- use_module('logger', [
+    log_info/1,
+    log_debug/1
+]).
+:- use_module('stream', [read_stream/3]).
+
 :- meta_predicate(endpoint_spec_pairs(2, +)).
 
 endpoint_spec_pairs(_Pairs, _IsExpanded).
@@ -23,26 +30,38 @@ replace(Target, Replacement, Char, In, Out) :-
     ).
 
 %% Expand goal so that Json spec is phrased.
-user:goal_expansion(Term, ExpandedTerm) :-
-    Term = (endpoint_spec_pairs(Pairs, IsExpanded)),
+user:goal_expansion(Goal, ExpandedGoal) :-
+    Goal = (endpoint_spec_pairs(Pairs, IsExpanded)),
+    prolog_load_context(source, SourceAtom),
+
+    atom_si(SourceAtom),
+
     if_(
-        dif(IsExpanded, true),
-        (prolog_load_context(source, SourceAtom),
-
-        atom_chars(SourceAtom, SourceChars),
-        append([RootDir, "./src/", Endpoint, ".pl"], SourceChars),
-
-        foldl(replace('/', '.'), Endpoint, "", FilenamePrefix),
-        append([RootDir, "doc/endpoints/", FilenamePrefix, ".value.json"], EndpointSpecJson),
-
-        once((
-            file_exists(EndpointSpecJson)
-        ;   throw(file_does_not_exist(EndpointSpecJson)) )),
-
-        open(EndpointSpecJson, read, Stream, [type(text)]),
-        read_stream(Stream, [], EndpointSpecJsonContent),
-        phrase(json_chars(pairs(Pairs)), EndpointSpecJsonContent),
-
-        ExpandedTerm = (endpoint_spec_pairs(Pairs, true))),
-        fail
+       dif(IsExpanded, false),
+       fail,
+       (expand_endpoint_spec_pairs(Pairs, SourceAtom, ExpandedGoal))
     ).
+
+%% replaces '/' with '.' in endpoint, producing endpoint spec basename
+%
+%% expand_endpoint_spec_pairs(+SourceAtom, -Spec.
+expand_endpoint_spec_pairs(Pairs, SourceAtom, endpoint_spec_pairs(Pairs, true)) :-
+    atom_si(SourceAtom),
+    atom_chars(SourceAtom, SourceChars),
+    path_canonical(SourceChars, CanonicalSourceChars),
+
+    (   append([Prefix, ".pl"], CanonicalSourceChars)
+    ->  append([RootDir, "src/", Endpoint], Prefix)
+    ;   throw(cannot_find_endpoint(CanonicalSourceChars)) ),
+
+    foldl(replace('/', '.'), Endpoint, "", Basename),
+    append([RootDir, "doc/endpoints/", Basename, ".value.json"], EndpointSpecJson),
+
+    once((
+        file_exists(EndpointSpecJson)
+    ;   throw(file_does_not_exist(EndpointSpecJson)) )),
+
+    open(EndpointSpecJson, read, Stream, [type(text)]),
+    read_stream(Stream, [], EndpointSpecJsonContent),
+    phrase(json_chars(pairs(Pairs)), EndpointSpecJsonContent),
+    log_debug([pairs:Pairs]).

--- a/src/app/bsky/graph/getList.pl
+++ b/src/app/bsky/graph/getList.pl
@@ -4,15 +4,26 @@
 
 :- use_module(library(assoc)).
 :- use_module(library(charsio)).
+:- use_module(library(clpz)).
 :- use_module(library(dcgs)).
 :- use_module(library(http/http_open)).
 :- use_module(library(lists)).
 :- use_module(library(pairs)).
 :- use_module(library(reif)).
+:- use_module(library(si)).
 :- use_module(library(serialization/json)).
+:- use_module(library(time)).
 
+:- use_module('../../../app/bsky/actor/getProfile', [
+    app__bsky__actor__getProfile/2
+]).
+:- use_module('../../../domain/events/app/bsky/actor/event_getProfile', [
+    onGetProfile/1
+]).
 :- use_module('../../../domain/events/app/bsky/graph/event_getList', [
-    onGetList/2,
+    onGetList/2
+]).
+:- use_module('../../../domain/events/app/bsky/graph/event_getListItem', [
     onGetListItem/2
 ]).
 :- use_module('../../../http', [
@@ -47,7 +58,7 @@
 %% app__bsky__graph__getList_endpoint(+OperationId, +ParamName, +Param, -Endpoint).
 app__bsky__graph__getList_endpoint(OperationId, ParamName, Param, Endpoint) :-
     public_bluesky_appview_api_endpoint(OperationId, EndpointWithoutParam),
-    concat_as_string([EndpointWithoutParam, "?", ParamName, "=", Param], [], Endpoint).
+    concat_as_string([EndpointWithoutParam, "?limit=6&", ParamName, "=", Param], [], Endpoint).
 
 %% app__bsky__graph__getList_headers(-ListHeaders).
 app__bsky__graph__getList_headers(ListHeaders) :-
@@ -61,6 +72,7 @@ send_request(MainListAtUri, ResponsePairs, StatusCode) :-
     pairs_keys(SpecPairs, [string(Verb)]),
     pairs_to_assoc(SpecPairs, SpecAssoc),
 
+    chars_si(Verb),
     atom_chars(VerbAtom, Verb),
     get_assoc(VerbAtom, SpecAssoc, EndpointSpecAssoc),
     get_assoc(parameters, EndpointSpecAssoc, Parameters),
@@ -80,25 +92,33 @@ send_request(MainListAtUri, ResponsePairs, StatusCode) :-
         method(VerbAtom),
         status_code(StatusCode),
         request_headers(ListHeaders),
-        headers(_ResponseHeaders)
+        headers(ResponseHeaders)
     ],
 
     app__bsky__graph__getList_endpoint(OperationId, ParamName, MainListAtUri, Endpoint),
 
     http_open(Endpoint, Stream, Options),
     log_debug(Options), !,
+    writeln(response_headers: ResponseHeaders),
 
     read_stream(Stream, BodyChars),
     phrase(json_chars(pairs(ResponsePairs)), BodyChars),
+    pairs_to_assoc(ResponsePairs, JSONAssoc),
+    get_assoc(list, JSONAssoc, List),
+    get_assoc(uri, List, ListUri),
 
     payload(BodyChars, Payload),
-    list_uri(ResponsePairs, ListUri),
-
-    % See ./domain/events/app/bsky/graph/event_getList.pl
+    % See ./domain/.../graph/event_getList.pl
     % where `onGetList` event handler is implemented
     onGetList(ListUri, Payload),
 
+    % Emits
+    % - `onGetListItem` event handled by ./domain/.../graph/event_getListsItem.pl,
+    % - `onGetProfile` event handled by ./domain/.../actor/event_getProfile.pl
+    list_uri(MainListAtUri, JSONAssoc, ListUri),
+
     append([OperationId, " call failed"], FailedHttpRequestErrorMessage),
+    chars_si(FailedHttpRequestErrorMessage),
     atom_chars(FailedHttpRequestErrorMessageAtom, FailedHttpRequestErrorMessage),
 
     if_(
@@ -118,23 +138,62 @@ payload(BodyChars, Payload) :-
     maplist(char_code_at, Utf8Bytes, Utf8BytesPayload),
     chars_base64(Utf8BytesPayload, Payload, []).
 
-%% list_uri(+ResponsePairs, -Uri).
-list_uri(ResponsePairs, Uri) :-
-    pairs_to_assoc(ResponsePairs, JSONAssoc),
+%% list_uri(+MainListAtUri, +JSONAssoc, -Uri).
+list_uri(MainListAtUri, JSONAssoc, Uri) :-
     get_assoc(list, JSONAssoc, List),
     get_assoc(items, JSONAssoc, Items),
 
     maplist(wrapped_pairs_to_assoc, Items, ItemsAssocs),
-    maplist(onGetListItem, ItemsAssocs, Items),
-
+    foldl(get_profile(MainListAtUri), ItemsAssocs, [], []),
+    maplist(ItemsAssocs, onGetListItem(Items)),
     get_assoc(uri, List, Uri).
+
+    %% get_profile(+MainListAtUri, +Assoc, +In, -In).
+    get_profile(MainListAtUri, Assoc, In, In) :-
+        get_assoc(subject, Assoc, Subject),
+        get_assoc(did, Subject, DID),
+
+        writeln(gettingProfileByDID(DID), true),
+        app__bsky__actor__getProfile(DID, Payload),
+
+        % [Content Write Operations (per account)](https://docs.bsky.app/docs/advanced-guides/rate-limits#content-write-operations-per-account)
+        TimeToWaitInSecBeforeNextWriteOperation is ceiling(5000/3600),
+
+        current_time(PreTimestamp),
+        phrase(format_time("%M:%S", PreTimestamp), PreCs),
+        writeln(before_sleep(PreCs), true),
+
+        writeln(about_to_wait_for(
+            TimeToWaitInSecBeforeNextWriteOperation
+        )-seconds, true),
+
+%        statistics(runtime, [PreCpuTime|_]),
+
+        sleep(TimeToWaitInSecBeforeNextWriteOperation),
+
+%        statistics(runtime, [PostCpuTime|_]),
+%        CpuTimeDifference is (PostCpuTime - PreCpuTime) * 1000,
+%        writeln(cpu_time_difference(CpuTimeDifference), true),
+
+        current_time(PostTimestamp),
+        phrase(format_time("%M:%S", PostTimestamp), PostCs),
+        writeln(after_sleep(PostCs), true),
+
+        writeln(received_payload(Payload), true),
+
+        pairs_to_assoc(Payload, PayloadAssoc),
+
+        get_assoc(followersCount, PayloadAssoc, FollowersCount),
+        get_assoc(followsCount, PayloadAssoc, FollowsCount),
+
+        onGetProfile(props(MainListAtUri, FollowersCount, FollowsCount, DID, Payload)).
 
 :- dynamic(app__bsky__graph__getList_memoized/2).
 
 %% memoize_app__bsky__graph__getList_memoized(+MainListAtUri, -Props).
 memoize_app__bsky__graph__getList_memoized(MainListAtUri, Props) :-
     catch(
-        send_request(MainListAtUri, Pairs, StatusCode),
+        (send_request(MainListAtUri, Pairs, StatusCode)),
         failed_http_request(Message, Pairs, StatusCode),
         log_info([Message])
     ),
@@ -142,6 +201,7 @@ memoize_app__bsky__graph__getList_memoized(MainListAtUri, Props) :-
     if_(
         dif(StatusCode, 200),
         (by_key("message", Pairs, ErrorMessageChars),
+        chars_si(ErrorMessageChars),
         atom_chars(ErrorMessage, ErrorMessageChars),
         log_info([ErrorMessage]), fail),
         (keys(Pairs, [], Keys),
@@ -155,5 +215,5 @@ memoize_app__bsky__graph__getList_memoized(MainListAtUri, Props) :-
 %% app__bsky__graph__getList(+MainListAtUri, -Props).
 app__bsky__graph__getList(MainListAtUri, Props) :-
     app__bsky__graph__getList_memoized(MainListAtUri, Props)
-    ->  true
+    ->  halt
     ;   memoize_app__bsky__graph__getList_memoized(MainListAtUri, Props).

--- a/src/domain/events/app/bsky/actor/event_getProfile.pl
+++ b/src/domain/events/app/bsky/actor/event_getProfile.pl
@@ -1,0 +1,66 @@
+:- module(event_getProfile, [
+    onGetProfile/1
+]).
+
+:- use_module(library(assoc)).
+:- use_module(library(charsio)).
+:- use_module(library(lists)).
+:- use_module(library(reif)).
+:- use_module(library(serialization/json)).
+
+:- use_module('../../../../../infrastructure/repository/repository_lists', [
+    by_list_uri_or_throw/2
+]).
+:- use_module('../../../../../infrastructure/repository/repository_publishers', [
+    by_criteria/3,
+    insert/2
+]).
+:- use_module('../../../../../logger', [
+    log_debug/1,
+    log_error/1,
+    log_info/1
+]).
+:- use_module('../../../../../serialization', [
+    char_code_at/2,
+    pairs_to_assoc/2,
+    to_json_chars/2
+]).
+:- use_module('../../../../../stream', [
+    writeln/1,
+    writeln/2
+]).
+
+%% Handling onGetProfile Event
+%
+%% onGetProfile(+ListURI, +DID, +Payload)
+onGetProfile(props(ListURI, FollowersCount, FollowsCount, DID, Payload)) :-
+    catch(
+        (once(repository_publishers:by_criteria(list_uri(ListURI), did(DID), Rows)),
+        ( ( nth0(0, Rows, FirstRow),
+            get_assoc(screen_name, FirstRow, PreExistingDID) )
+        ->  writeln('Pre-existing record for did':PreExistingDID, true)
+        ;   true )),
+        Cause,
+        if_(
+            Cause = cannot_read_rows_selected_by(_Selector),
+            once((
+                by_list_uri_or_throw(list_uri(ListURI), ListUriPairs),
+                get_assoc(list_id, ListUriPairs, ListId),
+                repository_publishers:insert(
+                    row(
+                        ListId,
+                        ListURI,
+                        FollowersCount,
+                        FollowsCount,
+                        DID,
+                        Payload
+                    ),
+                    InsertionResult
+                ),
+                log_info([list_insertion_result(InsertionResult)])
+            )),
+            throw(cannot_select_publishers(Cause))
+        )
+    ).
+
+%get_key(string(Key)-_Value, Key).

--- a/src/domain/events/app/bsky/graph/event_getList.pl
+++ b/src/domain/events/app/bsky/graph/event_getList.pl
@@ -1,6 +1,5 @@
 :- module(event_getList, [
-    onGetList/2,
-    onGetListItem/2
+    onGetList/2
 ]).
 
 :- use_module(library(assoc)).
@@ -29,6 +28,10 @@
     pairs_to_assoc/2,
     to_json_chars/2
 ]).
+:- use_module('../../../../../stream', [
+    writeln/1,
+    writeln/2
+]).
 
 %% Handling onGetList Event
 %
@@ -52,7 +55,7 @@ onGetList(ListUri, Payload) :-
             phrase(json_chars(pairs(Pairs)), JSONChars, []),
             maplist(get_key, Pairs, Keys),
             pairs_to_assoc(Pairs, _Assoc),
-            write_term('list keys':Keys, [double_quotes(true)]), nl
+            writeln('list keys':Keys, true)
         ;   true )),
         cannot_read_rows_selected_by(_Selector),
         catch(
@@ -72,43 +75,3 @@ onGetList(ListUri, Payload) :-
     ).
 
 get_key(string(Key)-_Value, Key).
-
-%% Handling onGetListItem Event
-%
-%% onGetListItem(+ItemAssoc, -Pairs)
-onGetListItem(ItemAssoc, pairs(UnwrappedPairs)) :-
-    write_term_to_chars(UnwrappedPairs, [quoted(true),double_quotes(true)], Chars),
-
-    chars_utf8bytes(Chars, Utf8Bytes),
-    maplist(char_code_at, Utf8Bytes, Utf8BytesPayload),
-    chars_base64(Utf8BytesPayload, Payload, []),
-
-    get_assoc('subject', ItemAssoc, Subject),
-    get_assoc(handle, Subject, ScreenName),
-
-    catch(
-        (once(repository_list_items:event_by_screen_name(ScreenName, Rows)),
-        ( ( nth0(0, Rows, FirstRow),
-            get_assoc(payload, FirstRow, Payload) )
-        ->
-            from_event(Payload, row(_,_,_,Handle,_)),
-            write_term('list item value related to "subject" key':Handle, [double_quotes(true)]), nl
-        ;   true )),
-        cannot_read_rows_selected_by(_),
-        (
-            once(repository_list_items:insert(
-                row(ScreenName, Payload),
-                InsertionResult
-            )),
-
-            from_event(Payload, RowFromPayload),
-            insert_list_items_if_not_exists(
-                RowFromPayload,
-                HeadersAndRowsSelectedByHandle
-            ),
-
-            write_term(screen_name:ScreenName, [double_quotes(true)]), nl,
-            write_term(insertion_result:InsertionResult, []), nl,
-            log_debug([payload:Payload]), nl
-        )
-    ).

--- a/src/domain/events/app/bsky/graph/event_getListItem.pl
+++ b/src/domain/events/app/bsky/graph/event_getListItem.pl
@@ -1,0 +1,70 @@
+:- module(event_getListItem, [
+    onGetListItem/2
+]).
+
+:- use_module(library(assoc)).
+:- use_module(library(charsio)).
+:- use_module(library(lists)).
+:- use_module(library(serialization/json)).
+
+:- use_module('../../../../../infrastructure/repository/repository_lists', [
+    insert/2
+]).
+:- use_module('../../../../../infrastructure/repository/repository_list_items', [
+    event_by_screen_name/2,
+    from_event/2,
+    record_by_screen_name/2,
+    insert_list_items_if_not_exists/2,
+    insert/2,
+    insert_record/2
+]).
+:- use_module('../../../../../logger', [
+    log_debug/1,
+    log_error/1,
+    log_info/1
+]).
+:- use_module('../../../../../serialization', [
+    char_code_at/2,
+    pairs_to_assoc/2,
+    to_json_chars/2
+]).
+
+%% Handling onGetListItem Event
+%
+%% onGetListItem(+ItemAssoc, +Pairs)
+onGetListItem(ItemAssoc, pairs(UnwrappedPairs)) :-
+    write_term_to_chars(UnwrappedPairs, [quoted(true),double_quotes(true)], Chars),
+
+    chars_utf8bytes(Chars, Utf8Bytes),
+    maplist(char_code_at, Utf8Bytes, Utf8BytesPayload),
+    chars_base64(Utf8BytesPayload, Payload, []),
+
+    get_assoc('subject', ItemAssoc, Subject),
+    get_assoc(handle, Subject, ScreenName),
+
+    catch(
+        (once(repository_list_items:event_by_screen_name(ScreenName, Rows)),
+        ( ( nth0(0, Rows, FirstRow),
+            get_assoc(payload, FirstRow, Payload) )
+        ->
+            from_event(Payload, row(_,_,_,Handle,_)),
+            write_term('list item value related to "subject" key':Handle, [double_quotes(true)]), nl
+        ;   true )),
+        cannot_read_rows_selected_by(_),
+        (
+            once(repository_list_items:insert(
+                row(ScreenName, Payload),
+                InsertionResult
+            )),
+
+            from_event(Payload, RowFromPayload),
+            insert_list_items_if_not_exists(
+                RowFromPayload,
+                _
+            ),
+
+            write_term(screen_name:ScreenName, [double_quotes(true)]), nl,
+            write_term(insertion_result:InsertionResult, []), nl,
+            log_debug([payload:Payload]), nl
+        )
+    ).

--- a/src/infrastructure/pg/client.pl
+++ b/src/infrastructure/pg/client.pl
@@ -75,14 +75,15 @@ query(Query, RemoveResultFile, TuplesOnly, TempFile, Result) :-
             "psql ",
             TuplesOnlyOption,
             "--csv ",
-            "--no-align ",
-            "--no-readline ",
-            "--quiet ",
-            "--username='", Username, "' ",
             "--dbname='", DbName, "' ",
             "--host='", Host, "' ",
+            "--no-align ",
+            "--no-readline ",
+            "--output='", TempFile, "' ",
             "--port='", Port, "' ",
-            "--output='", TempFile, "' "
+            "--quiet ",
+            "--set ON_ERROR_STOP=1 ",
+            "--username='", Username, "' "
         ], QueryCommand)
     ->  true
     ;   throw(cannot_execute_sql_query) ),

--- a/src/infrastructure/repository/repository_list_items.pl
+++ b/src/infrastructure/repository/repository_list_items.pl
@@ -458,8 +458,7 @@ insert_record(
             ],
             InsertRecordQuery
         ),
-
-        write_term(query:InsertRecordQuery, [double_quotes(true)]),
+        log_debug([query:InsertRecordQuery]),
 
         (   once(query_result(
                 InsertRecordQuery,
@@ -519,8 +518,7 @@ insert_list_items_if_not_exists(
     HeadersAndRowsSelectedByHandle
 ) :-
     catch(
-        (record_by_screen_name(Handle, HeadersAndRowsSelectedByHandle),
-        writeq(rows: HeadersAndRowsSelectedByHandle)),
+        record_by_screen_name(Handle, HeadersAndRowsSelectedByHandle),
         E,
         (log_info([E]),
         catch(
@@ -541,7 +539,7 @@ insert_list_items_if_not_exists(
     ).
 
 %% event(+Payload, -Row).
-from_event(Payload, row(Avatar, Description, Did, Handle, DisplayName)) :-
+from_event(Payload, row(Avatar, Description, DID, Handle, DisplayName)) :-
     chars_base64(Utf8BytesPayload, Payload, []),
     maplist(char_code, Utf8BytesPayload, Utf8Bytes),
     chars_utf8bytes(PayloadChars, Utf8Bytes),
@@ -553,29 +551,29 @@ from_event(Payload, row(Avatar, Description, Did, Handle, DisplayName)) :-
     get_assoc(subject, Assoc, Subject),
     assoc_to_keys(Subject, SubjectKeys),
 
-    write_term('list items keys':SubjectKeys, [double_quotes(true)]), nl,
+    log_debug([['list items keys':SubjectKeys, [double_quotes(true)]], nl]),
 
     get_assoc(avatar, Subject, Avatar),
-    write_term(avatar:Avatar, [double_quotes(true)]), nl,
+    log_debug([[avatar:Avatar, [double_quotes(true)]], nl]),
     get_assoc(displayName, Subject, DisplayName),
-    write_term(displayName:DisplayName, [double_quotes(true)]), nl,
-    get_assoc(did, Subject, Did),
-    write_term(did:Did, [double_quotes(true)]), nl,
+    log_debug([[displayName:DisplayName, [double_quotes(true)]], nl]),
+    get_assoc(did, Subject, DID),
+    log_debug([[did:DID, [double_quotes(true)]], nl]),
     get_assoc(handle, Subject, Handle),
-    write_term(handle:Handle, [double_quotes(true)]), nl,
+    log_debug([[handle:Handle, [double_quotes(true)]], nl]),
     get_assoc(createdAt, Subject, CreatedAt),
-    write_term(createdAt:CreatedAt, [double_quotes(true)]), nl,
+    log_debug([[createdAt:CreatedAt, [double_quotes(true)]], nl]),
     get_assoc(indexedAt, Subject, IndexedAt),
-    write_term(indexedAt:IndexedAt, [double_quotes(true)]), nl,
+    log_debug([[indexedAt:IndexedAt, [double_quotes(true)]], nl]),
 
     once(catch(
         ( ( get_assoc(associated, Subject, Associated),
             get_assoc(chat, Associated, Chat),
             get_assoc(allowIncoming, Chat, AllowIncomingChat),
-            write_term(associated:AllowIncomingChat, [double_quotes(true)]), nl
+            log_debug([[associated:AllowIncomingChat, [double_quotes(true)]], nl])
         ;   throw(key_not_found(associated)), nl ),
         ( get_assoc(description, Subject, Description),
-            write_term(description:Description, [double_quotes(true)]), nl
+            log_debug([[description:Description, [double_quotes(true)]], nl])
         ;   Description = "" )),
         key_not_found(Field),
         (write_term(not_found(Field), [double_quotes(true)]), nl)

--- a/src/infrastructure/repository/repository_publishers.pl
+++ b/src/infrastructure/repository/repository_publishers.pl
@@ -1,0 +1,301 @@
+:- module(repository_publishers, [
+    by_criteria/3,
+    count/1,
+    insert/2,
+    next_id/1,
+    query/1
+]).
+
+:- use_module(library(assoc)).
+:- use_module(library(charsio)).
+:- use_module(library(clpz)).
+:- use_module(library(dcgs)).
+:- use_module(library(files)).
+:- use_module(library(lists)).
+:- use_module(library(pio)).
+:- use_module(library(reif)).
+:- use_module(library(serialization/json)).
+:- use_module(library(si)).
+:- use_module(library(uuid)).
+
+:- use_module('repository_dcgs', [
+    rows//1,
+    to_json/3
+]).
+:- use_module('../pg/client', [
+    query_result/2,
+    query_result_from_file/3
+]).
+:- use_module('../../logger', [
+    log_debug/1,
+    log_info/1
+]).
+:- use_module('../../os_ext', [remove_temporary_file/1]).
+:- use_module('../../serialization', [
+    pairs_to_assoc/2,
+    to_json_chars/2
+]).
+:- use_module('../../stream', [
+    read_stream/2,
+    writeln/1,
+    writeln/2
+]).
+
+%% count(-Count).
+count(Count) :-
+    table(Table),
+    append(
+       ["select count(*) as Count from public.", Table],
+       Query
+    ),
+    query_result(
+        Query,
+        Count
+    ).
+
+%% query(-HeadersAndRows).
+query(HeadersAndRows) :-
+    % Executed to fetch column names
+    query(EmptyResults, false, 0),
+    nth0(0, EmptyResults, Headers),
+    query(Rows, true, "ALL"),
+    maplist(to_json(Headers), Rows, Pairs),
+    maplist(pairs_to_assoc, Pairs, HeadersAndRows).
+
+%% all_clauses(-Query, +Limit).
+all_clauses(Query, Limit) :-
+    select_clause(SelectClause),
+    from_clause(FromClause),
+
+    % Accepting "ALL" as limit
+    % and sufficiently instantiated integers
+    ( ( integer_si(Limit),
+        number_chars(Limit, LimitClause) )
+    ->  true
+    ;   Limit = "ALL",
+        LimitClause = Limit ),
+
+
+    append(
+        SelectClause,
+        FromClause,
+        SelectFromClauses
+    ),
+
+    append(
+        [
+            SelectFromClauses,
+            "ORDER BY ",
+            "t.id DESC, ",
+            "t.name ASC, ",
+            "t.screen_name ASC ",
+            "OFFSET 0 ",
+            "LIMIT ", LimitClause, ";"
+        ],
+        Query
+    ).
+
+%% query(-Rows, +TuplesOnly, +Limit).
+query(Rows, TuplesOnly, Limit) :-
+    all_clauses(Query, Limit),
+    once(query_result_from_file(
+        Query,
+        TuplesOnly,
+        TmpFile
+    )),
+    read_rows(TmpFile, Rows).
+
+%% Query max id, then increment it by 1 to declare what next max id will be.
+%
+%% next_id(-NextId).
+next_id(NextId) :-
+    query_max_id(Rows),
+    nth0(0, Rows, Headers),
+    nth0(0, Headers, SingleField),
+    number_chars(MaxId, SingleField),
+    NextId #= MaxId + 1,
+    (   integer_si(NextId)
+    ->  true
+    ;   throw(invalid_list_id(NextId)) ).
+
+    %% query_max_id(-MaxId).
+    query_max_id(MaxId) :-
+        table(Table),
+        append(
+            [
+                "SELECT COALESCE(r.id::bigint, 0) pk ",
+                "FROM ", Table, " r ",
+                "ORDER BY r.id DESC ",
+                "LIMIT 1;"
+            ],
+            Query
+        ),
+        once(query_result_from_file(
+            Query,
+            true,
+            TmpFile
+        )),
+        read_rows(TmpFile, MaxId).
+
+        %% table(-Table)
+        table("publishers_list").
+
+%% by_list_uri(+ListURI, +DID, -HeadersAndRows).
+by_criteria(list_uri(ListURI), did(DID), HeadersAndRows) :-
+    chars_si(DID),
+    select_clause(SelectClause),
+    from_clause(FromClause),
+    append([
+        SelectClause,
+        FromClause, " r ",
+        "WHERE ",
+        "r.created_at::date > '2024-12-31'::date ",
+        "AND r.screen_name = '", DID, "' ",
+        "AND r.name = '", ListURI, "' ",
+        "OFFSET 0 "
+    ], SelectByDID),
+    append(
+        [
+            SelectByDID,
+            "LIMIT 0;"
+        ],
+        QueryHeaders
+    ),
+    once(query_result_from_file(
+        QueryHeaders,
+        false,
+        HeadersOnlyTempFile
+    )),
+    read_rows(HeadersOnlyTempFile, HeadersRows),
+
+    nth0(0, HeadersRows, Headers),
+    append(
+        [
+            SelectByDID,
+            "LIMIT ALL;"
+        ],
+        SelectByDIDWithoutLimit
+    ),
+    writeln(selection_query(SelectByDIDWithoutLimit)), nl,
+
+    once(query_result_from_file(
+        SelectByDIDWithoutLimit,
+        true,
+        ByDIDTmpFile
+    )),
+    (   read_rows(ByDIDTmpFile, Rows)
+    ->  true
+    ;   throw(cannot_read_rows_selected_by(list_id)) ),
+
+    maplist(to_json(Headers), Rows, Pairs),
+    maplist(pairs_to_assoc, Pairs, HeadersAndRows).
+
+    %% from_clause(-FromClause).
+    from_clause(FromClause) :-
+        table(Table),
+        append(["FROM public.", Table], FromClause).
+
+    %% read_rows(+TmpFile, -Rows).
+    read_rows(TmpFile, Rows) :-
+        once(open(TmpFile, read, Stream, [type(text)])),
+        (   file_exists(TmpFile)
+        ->  true
+        ;   write(file_does_not_exist), halt ),
+
+        read_stream(Stream, StreamRows),
+        once(phrase(rows(Rows), StreamRows, [])),
+        remove_temporary_file(TmpFile).
+
+    %% select_clause(-SelectClause).
+    select_clause(SelectClause) :-
+        append(
+            [
+                "SELECT ",
+                "r.name as string__name, ",
+                "r.screen_name as string__screen_name, ",
+                "r.list_id as string__list_id, ",
+                "r.public_id as string__public_id, ",
+                "r.total_members as number__total_members, ",
+                "r.total_statuses as number__total_statuses "
+            ],
+            SelectClause
+        ).
+
+%% insert(+Row, -InsertionResult).
+insert(row(ListId, ListURI, _FollowersCount, _FollowsCount, DID, _), InsertionResult) :-
+    count_matching_records(row(ListURI, DID), TotalMatchingRecords),
+
+    if_(
+        dif(1, TotalMatchingRecords),
+       (next_id(NextId),
+        number_chars(NextId, NextIdChars),
+        uuidv4_string(PublicId),
+        table(Table),
+        append(
+            [
+                "INSERT INTO public.", Table, " (",
+                "   id,                 ",
+                "   list_id,            ",
+                "   public_id,          ",
+                "   name,               ",
+                "   screen_name,        ",
+                "   locked,             ",
+                "   created_at          ",
+                ") VALUES (             ",
+                "'", NextIdChars, "',   ",
+                " ", ListId, ",         ",
+                "'", PublicId, "',      ",
+                "'", ListURI, "',       ",
+                "'", DID, "',           ",
+                "   false,              ",
+                "   NOW()               ",
+                ")"
+            ],
+            Query
+        ),
+        once(query_result(
+            Query,
+            InsertionResult
+        ))),
+        (table(Table),
+        append(
+            [
+                "SELECT                             ",
+                "r.id AS number__id,                ",
+                "r.public_id AS string__public_id,  ",
+                "r.name AS string__name             ",
+                "FROM public.", Table, " r     ",
+                "WHERE                              ",
+                "r.screen_name = '", DID, "'        ",
+                "AND r.name = '", ListURI, "'      ;"
+            ],
+            SelectQuery
+        ),
+        once(query_result(
+            SelectQuery,
+            SelectionResult
+        )),
+        chars_base64(DecodedBase64Payload, SelectionResult, []),
+
+        maplist(char_code, DecodedBase64Payload, DecodedBytes),
+        chars_utf8bytes(DecodedChars, DecodedBytes),
+        append([Prefix, ['"']], DecodedChars),
+        append([['"'], Suffix], Prefix),
+        to_json_chars(Suffix, JSONChars),
+        log_info([JSONChars]),
+        InsertionResult = ok)
+    ).
+
+    %%% count_matching_records(+Row, -Result).
+    count_matching_records(row(ListURI, DID), Result) :-
+        table(Table),
+        append([
+            "SELECT count(*) how_many_records ",
+            "FROM public.", Table, " r ",
+            "WHERE name = '", ListURI, "' ",
+            "AND screen_name = '", DID, "';"
+        ], SelectQuery),
+        once(query_result(
+            SelectQuery,
+            Result
+        )).

--- a/src/logger.pl
+++ b/src/logger.pl
@@ -59,7 +59,6 @@ log_debug(Messages) :-
         above_debug_level.
 
     debug(Messages) :-
-        write(why_does_it_log_at_debug_level), nl,
         log(Messages).
 
 log_info(Messages) :-

--- a/src/serialization.pl
+++ b/src/serialization.pl
@@ -35,6 +35,7 @@ char_code_at(Code, Char) :-
 
 %% to_json_chars(+Chars, -JSONChars).
 to_json_chars(Chars, JSONChars) :-
+    chars_si(Chars),
     atom_chars(Atom, Chars),
     temporary_file("beautify_json", ".json", JsonFile),
     open(JsonFile, write, WriteToJsonStream, [type(text)]),
@@ -88,7 +89,7 @@ keys([string(KeyChars)-_|RemainingKeys], KeysIn, KeysOut) :-
 
 %% wrapped_pairs_to_assoc(+Pairs, -Assoc).
 wrapped_pairs_to_assoc(pairs(UnwrappedPairs), Assoc) :-
-    pairs_to_assoc(UnwrappedPairs, Assoc).
+    once(pairs_to_assoc(UnwrappedPairs, Assoc)).
 
 %% pairs_to_assoc(+Pair, -Assoc).
 pairs_to_assoc(Pairs, Assoc) :-
@@ -101,18 +102,22 @@ pairs_to_assoc(Pairs, Assoc) :-
 % Relates right boolean, number, string, list with the same type
 % Relates right pairs with an assoc
 without_type(string(Key)-boolean(Value), KeyAtom-Value) :-
+    log_debug([kv:string(Key)-boolean(Value)]),
     atom_chars(KeyAtom, Key).
 without_type(string(Key)-string(Value), KeyAtom-Value) :-
+    log_debug([kv:string(Key)-string(Value)]),
     atom_chars(KeyAtom, Key).
 without_type(string(Key)-number(Value), KeyAtom-Value) :-
+    log_debug([kv:string(Key)-number(Value)]),
     atom_chars(KeyAtom, Key).
 without_type(string(Key)-list(Value), KeyAtom-Value) :-
+    log_debug([kv:string(Key)-list(Value)]),
     atom_chars(KeyAtom, Key).
 without_type(string(Key)-pairs(Value), KeyAtom-ValueAssoc) :-
     atom_chars(KeyAtom, Key),
     pairs_to_assoc(Value, ValueAssoc).
-without_type(Left-Right, _) :-
-    throw(cannot_remove_type(Left, Right)).
+without_type(Left-Right, UnknownKind) :-
+    throw(cannot_remove_type(Left, Right)-because_of(UnknownKind)).
 
 %% unwrap_pairs(+Pairs, -UnwrappedPairs).
 unwrap_pairs(pairs(UnwrappedPairs), UnwrappedPairs).

--- a/src/stream.pl
+++ b/src/stream.pl
@@ -11,22 +11,23 @@
 
 % read_stream(+Stream, -Out).
 read_stream(Stream, Out) :-
-    once(read_stream(Stream, [], Out)),
-    close(Stream).
+    once(read_stream(Stream, [], Out)).
 
 % read_stream(+Stream, +In, -Out).
 read_stream(Stream, In, Out) :-
     get_char(Stream, Char),
-    (   Char = end_of_file
-    ->  Out = In
-    ;   read_stream(Stream, In, ReadOut),
-        Out = [Char|ReadOut] ).
+    if_(
+        Char = end_of_file,
+        (close(Stream),
+        Out = In),
+        (read_stream(Stream, In, ReadOut),
+        Out = [Char|ReadOut] )
+    ).
 
 writeln(_Term) :- !.
 
 writeln_(_Term, false) :- !.
 writeln_(Term, true) :-
-    chars_si(Term),
     write_term(Term, [double_quotes(true)]),
     nl.
 writeln_(Term, true) :-


### PR DESCRIPTION
fix: Removed unused variables, log
refactor: Separate getList event handler from getListItem event handler
refactor: Group predicates called on `make infrastructure__lists__next_event_id` phony target run
feat: Group predicates called on `make infrastructure__lists__next_id` phony target run
refactor: Using canonical paths in api.pl to expand endpoint spec
fix: Fix goal expansion to utilize getProfile spec
fix: Restored endpoint spec expansion
fix: Repair goal expansion responsible for spec phrasing
feat: Save each publisher profile on list item retrieval
feat: `make app__bsky__actor__getProfile`
doc: Replaced output writes with debug traces
fix: Ensured failing command execution throws with culprit message
doc: Replaced output writes with debug traces
fix: Removed ambiguity with regard to list_uri, did criteria
doc: Replaced debug traces with conditional write to standard output
fix: Renamed alias to match database table column name
chore: Removed quoted write to standard output
fix: Added missing predicate import
chore: Replace term writing with conditional double quoted write
refactor: Revised how stream is read until end_of_file is encountered
doc: Tracing pre-exising publishers records
doc: Replaced debugging traces with conditional writes to standard output
feat: Added user-agent header to request headers lists
fix: Wait for some time before next write operation
feat: Added bearer token authorization header to request headers lists on get profile event handling
chore: Removed debugging trace
doc: Write response headers to standard output on condition
chore: Debugging why http_open stop working after 5 calls